### PR TITLE
Modify regex to match quoted arguments

### DIFF
--- a/src/main/java/com/bunjlabs/jecue/CueLoader.java
+++ b/src/main/java/com/bunjlabs/jecue/CueLoader.java
@@ -147,7 +147,7 @@ public class CueLoader {
             if (input.startsWith(type.name())) {
                 List<String> list = new ArrayList<String>();
 
-                Matcher m = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(input.substring(type.name().length() + 1));
+                Matcher m = Pattern.compile("([^\"]\\S*|\"[^\"]*\")\\s*").matcher(input.substring(type.name().length() + 1));
 
                 while (m.find()) list.add(m.group(1).replace("\"", ""));
 


### PR DESCRIPTION
When I processed some cue files, I came across some arguments with double quotes, some of them even are empty.

I modified the regex, so that those arguments can be processed correctly.